### PR TITLE
Add Travis CI for supported targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,169 @@
+# Copyright (c) 2020 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: sh
+os: linux
+dist: focal
+
+cache:
+  pip: true
+  ccache: true
+  directories:
+    # Cache arm-none-eabi compiler
+    - ${HOME}/.cache/deps
+    # It looks like ccache for arm-none-eabi is not yet supported by Travis.
+    # Therefore manually adding ccache directory to cache
+    - ${HOME}/.ccache
+
+matrix:
+  include:
+
+    # ARM_MUSCA_S1
+
+    - &mbed-psa-compile-test
+      stage: "Compile"
+      name: "Compile PSA example - release (ARM_MUSCA_S1)"
+      env: TARGET_NAME=ARM_MUSCA_S1 PROFILE=release CACHE_NAME=release-ARM_MUSCA_S1
+      language: python
+      python: 3.8
+      install:
+        # Install arm-none-eabi-gcc
+        - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A" --output gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - tar xf gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        - popd
+        - arm-none-eabi-gcc --version
+        # Setup ccache
+        - ccache -o compiler_check=content
+        - pushd /usr/lib/ccache
+        - sudo ln -s $(which ccache) arm-none-eabi-gcc
+        - sudo ln -s $(which ccache) arm-none-eabi-g++
+        - export PATH="/usr/lib/ccache:$PATH"
+        - popd
+        # Fetch mbed-os: We use manual clone, with depth=1 and --single-branch to save time.
+        - git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git;
+        # Install Mbed CLI and dependencies
+        - pip install --upgrade mbed-cli
+        - pip install -r mbed-os/requirements.txt
+      script:
+        - echo mbed compile -t GCC_ARM -m ${TARGET_NAME} --profile ${PROFILE}
+        - mbed compile -t GCC_ARM -m ${TARGET_NAME} --profile ${PROFILE}
+        - ccache -s
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (ARM_MUSCA_S1)"
+      env: TARGET_NAME=ARM_MUSCA_S1 PROFILE=develop CACHE_NAME=develop-ARM_MUSCA_S1
+
+    # ARM_MUSCA_B1
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (ARM_MUSCA_B1)"
+      env: TARGET_NAME=ARM_MUSCA_B1 PROFILE=release CACHE_NAME=release-ARM_MUSCA_B1
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (ARM_MUSCA_B1)"
+      env: TARGET_NAME=ARM_MUSCA_B1 PROFILE=develop CACHE_NAME=develop-ARM_MUSCA_B1
+
+    # K64F
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (K64F)"
+      env: TARGET_NAME=K64F PROFILE=release CACHE_NAME=release-K64F
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (K64F)"
+      env: TARGET_NAME=K64F PROFILE=develop CACHE_NAME=develop-K64F
+
+    # K66F
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (K66F)"
+      env: TARGET_NAME=K66F PROFILE=release CACHE_NAME=release-K66F
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (K66F)"
+      env: TARGET_NAME=K66F PROFILE=develop CACHE_NAME=develop-K66F
+
+    # NUCLEO_F429ZI
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (NUCLEO_F429ZI)"
+      env: TARGET_NAME=NUCLEO_F429ZI PROFILE=release CACHE_NAME=release-NUCLEO_F429ZI
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (NUCLEO_F429ZI)"
+      env: TARGET_NAME=NUCLEO_F429ZI PROFILE=develop CACHE_NAME=develop-NUCLEO_F429ZI
+
+    # FVP_MPS2_M0
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (FVP_MPS2_M0)"
+      env: TARGET_NAME=FVP_MPS2_M0 PROFILE=release CACHE_NAME=release-FVP_MPS2_M0
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (FVP_MPS2_M0)"
+      env: TARGET_NAME=FVP_MPS2_M0 PROFILE=develop CACHE_NAME=develop-FVP_MPS2_M0
+
+    # FVP_MPS2_M0P
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (FVP_MPS2_M0P)"
+      env: TARGET_NAME=FVP_MPS2_M0P PROFILE=release CACHE_NAME=release-FVP_MPS2_M0P
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (FVP_MPS2_M0P)"
+      env: TARGET_NAME=FVP_MPS2_M0P PROFILE=develop CACHE_NAME=develop-FVP_MPS2_M0P
+
+    # FVP_MPS2_M3
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (FVP_MPS2_M3)"
+      env: TARGET_NAME=FVP_MPS2_M3 PROFILE=release CACHE_NAME=release-FVP_MPS2_M3
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (FVP_MPS2_M3)"
+      env: TARGET_NAME=FVP_MPS2_M3 PROFILE=develop CACHE_NAME=develop-FVP_MPS2_M3
+
+    # FVP_MPS2_M4
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (FVP_MPS2_M4)"
+      env: TARGET_NAME=FVP_MPS2_M4 PROFILE=release CACHE_NAME=release-FVP_MPS2_M4
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (FVP_MPS2_M4)"
+      env: TARGET_NAME=FVP_MPS2_M4 PROFILE=develop CACHE_NAME=develop-FVP_MPS2_M4
+
+    # FVP_MPS2_M7
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (FVP_MPS2_M7)"
+      env: TARGET_NAME=FVP_MPS2_M7 PROFILE=release CACHE_NAME=release-FVP_MPS2_M7
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (FVP_MPS2_M7)"
+      env: TARGET_NAME=FVP_MPS2_M7 PROFILE=develop CACHE_NAME=develop-FVP_MPS2_M7
+
+    # GD32_F450ZI
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - release (GD32_F450ZI)"
+      env: TARGET_NAME=GD32_F450ZI PROFILE=release CACHE_NAME=release-GD32_F450ZI
+
+    - <<: *mbed-psa-compile-test
+      name: "Compile PSA example - develop (GD32_F450ZI)"
+      env: TARGET_NAME=GD32_F450ZI PROFILE=develop CACHE_NAME=develop-GD32_F450ZI


### PR DESCRIPTION
This is based on https://github.com/ARMmbed/mbed-os-example-blinky/blob/development/.travis.yml but uses Mbed CLI 1.0 instead of CMake.

List of targets:
* ARM_MUSCA_S1
* ~ARM_MUSCA_S1_NS~ ([identical to ARM_MUSCA_S1](https://github.com/ARMmbed/mbed-os/pull/12955) for backward compatibility)
* ARM_MUSCA_B1
* ~ARM_MUSCA_B1_NS~ (identical to ARM_MUSCA_B1)
* K64F
* K66F
* NUCLEO_F429ZI
* FVP_MPS2_M0
* FVP_MPS2_M0P
* FVP_MPS2_M3
* FVP_MPS2_M4
* FVP_MPS2_M7
* GD32_F450ZI

Note: `CYTFM_064B0S2_4343W` is excluded for now due to Python failure of Cypress signing tool during Post-Build. This happens to any Mbed application for this target, I've created https://github.com/ARMmbed/mbed-os/issues/14022.