### PR TITLE
Support Mbed CLI 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,17 @@
-# Python CircleCI 2.0 configuration file
+# CircleCI 2.1 configuration file
 #
-# Check https://circleci.com/docs/2.0/language-python/ for more details
-#
-version: 2
+version: 2.1
+commands:
+  compile:
+    parameters:
+      target:
+        type: string
+      profile:
+        type: string
+    steps:
+      - run: |
+          cd mbed-os-example-psa
+          mbed compile -t GCC_ARM -m <<parameters.target>> --profile <<parameters.profile>>
 jobs:
   build:
     docker:
@@ -14,5 +23,69 @@ jobs:
       - run: |
           cd mbed-os-example-psa
           mbed deploy
-          mbed compile -t GCC_ARM -m K64F
-
+      - compile:
+          target: "ARM_MUSCA_S1"
+          profile: "develop"
+      - compile:
+          target: "ARM_MUSCA_S1"
+          profile: "release"
+      - compile:
+          target: "ARM_MUSCA_B1"
+          profile: "develop"
+      - compile:
+          target: "ARM_MUSCA_B1"
+          profile: "release"
+      - compile:
+          target: "K64F"
+          profile: "develop"
+      - compile:
+          target: "K64F"
+          profile: "release"
+      - compile:
+          target: "K66F"
+          profile: "develop"
+      - compile:
+          target: "K66F"
+          profile: "release"
+      - compile:
+          target: "NUCLEO_F429ZI"
+          profile: "develop"
+      - compile:
+          target: "NUCLEO_F429ZI"
+          profile: "release"
+      - compile:
+          target: "FVP_MPS2_M0"
+          profile: "develop"
+      - compile:
+          target: "FVP_MPS2_M0"
+          profile: "release"
+      - compile:
+          target: "FVP_MPS2_M0P"
+          profile: "develop"
+      - compile:
+          target: "FVP_MPS2_M0P"
+          profile: "release"
+      - compile:
+          target: "FVP_MPS2_M3"
+          profile: "develop"
+      - compile:
+          target: "FVP_MPS2_M3"
+          profile: "release"
+      - compile:
+          target: "FVP_MPS2_M4"
+          profile: "develop"
+      - compile:
+          target: "FVP_MPS2_M4"
+          profile: "release"
+      - compile:
+          target: "FVP_MPS2_M7"
+          profile: "develop"
+      - compile:
+          target: "FVP_MPS2_M7"
+          profile: "release"
+      - compile:
+          target: "GD32_F450ZI"
+          profile: "develop"
+      - compile:
+          target: "GD32_F450ZI"
+          profile: "release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,15 @@ cache:
     # Therefore manually adding ccache directory to cache
     - ${HOME}/.ccache
 
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ focal main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+    packages:
+      - cmake
+      - ninja-build
+
 matrix:
   include:
 
@@ -47,6 +56,14 @@ matrix:
         - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
         - popd
         - arm-none-eabi-gcc --version
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
         # Setup ccache
         - ccache -o compiler_check=content
         - pushd /usr/lib/ccache
@@ -57,11 +74,11 @@ matrix:
         # Fetch mbed-os: We use manual clone, with depth=1 and --single-branch to save time.
         - git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git;
         # Install Mbed CLI and dependencies
-        - pip install --upgrade mbed-cli
-        - pip install -r mbed-os/requirements.txt
+        - pip install --upgrade mbed-tools
+        - pip install -r mbed-os/tools/cmake/requirements.txt
       script:
-        - echo mbed compile -t GCC_ARM -m ${TARGET_NAME} --profile ${PROFILE}
-        - mbed compile -t GCC_ARM -m ${TARGET_NAME} --profile ${PROFILE}
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *mbed-psa-compile-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET mbed-os-example-psa)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(${MBED_PATH})
+
+add_executable(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        mbed-os
+        mbed-psa
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/README.md
+++ b/README.md
@@ -8,22 +8,49 @@ You can build this project with all supported [Mbed OS build tools](https://os.m
 1. From the command-line, import the example: `mbed import mbed-os-example-psa`
 1. Change the current directory to where the project was imported.
 
+## Mbed OS build tools
+
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-psa`
+1. Change the current directory to where the project was imported.
+
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+1. From the command-line, import the example: `mbed import mbed-os-example-psa`
+1. Change the current directory to where the project was imported.
+
 ## Application functionality
 
 The `main()` function queries the PSA version and toggles the state of a digital output connected to an LED on the board.
 
 ## Building and running
 
-1. Connect a USB cable between the USB port on the target and the host computer.
-1. Run the following command to build the example project, program the microcontroller flash memory, and open a serial terminal:
+1. Connect a USB cable between the USB port on the board and the host computer.
+1. Run the following command to build the example project and program the microcontroller flash memory:
 
-   ```
-   mbed compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm --baud 115200
-   ```
+    * Mbed CLI 2
+
+    ```bash
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash
+    ```
+
+    * Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash
+    ```
+
+Your PC may take a few minutes to compile your code.
+
+The binary is located at:
+* **Mbed CLI 2** - `./cmake_build/<TARGET>/<PROFILE>/<TOOLCHAIN>/mbed-os-example-psa.bin`</br>
+* **Mbed CLI 1** - `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-psa.bin`
+
+Alternatively, you can manually copy the binary to the board, which you mount on the host computer over USB.
 
 **Note:**  The serial terminal baud rate should be set to 115200 for this example.
-
-The binary is located at `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-psa.bin`.
 
 ## Expected output
 


### PR DESCRIPTION
This is based on `CMakeLists.txt` from mbed-os-example-blinky, with `mbed-psa` added to the list of libraries to link.
The Travis script has been changed to build with Mbed CLI 2 (only) _to align with other Mbed official examples_ (e.g. [mbed-os-example-blinky](https://github.com/ARMmbed/mbed-os-example-blinky/blob/master/.travis.yml)).

Tested:
* Compilation for K64F, ARM_MUSCA_B1, ARM_MUSCA_S1
* Running on K64F (we can only run it on Musca B1 and S1 after we added post binary hooks for them)