### PR TITLE
Add a minimal .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: mbedos/mbed-os-env:stable
+    working_directory: ~
+    steps:
+      - checkout:
+          path: mbed-os-example-psa
+      - run: |
+          cd mbed-os-example-psa
+          mbed deploy
+          mbed compile -t GCC_ARM -m K64F
+


### PR DESCRIPTION
To enable Circle CI for this project, `.circleci/config.yml` needs to exist already. This PR adds a basic one (K64F only) for this purpose.

Once this is merged, we can enable Circle CI and try more complex configuration in #20 